### PR TITLE
add a --encoding command line option

### DIFF
--- a/cheetah/CheetahWrapper.py
+++ b/cheetah/CheetahWrapper.py
@@ -173,6 +173,7 @@ class CheetahWrapper(object):
         pao("--templateAPIClass", action="store", dest="templateClassName", default=None, help='Name of a subclass of Cheetah.Template.Template to use for compilation, e.g. MyTemplateClass')
         pao("--parallel", action="store", type="int", dest="parallel", default=1, help='Compile/fill templates in parallel, e.g. --parallel=4')
         pao('--shbang', dest='shbang', default='#!/usr/bin/env python', help='Specify the shbang to place at the top of compiled templates, e.g. --shbang="#!/usr/bin/python2.6"')
+        pao('--encoding', dest='encoding', default=None, help='Specify the encoding of source files (e.g. \'utf-8\' to force input files to be interpreted as UTF-8)')
 
         opts, files = self.parser.parse_args(args)
         self.opts = opts

--- a/cheetah/Compiler.py
+++ b/cheetah/Compiler.py
@@ -18,6 +18,7 @@ import time
 import random
 import warnings
 import copy
+import codecs
 
 from Cheetah.Version import Version, VersionTuple
 from Cheetah.SettingsManager import SettingsManager
@@ -99,6 +100,7 @@ _DEFAULT_COMPILER_SETTINGS = [
     ('allowEmptySingleLineMethods', False, ''),
     ('allowNestedDefScopes', True, ''),
     ('allowPlaceholderFilterArgs', True, ''),
+    ('encoding', None, 'The encoding to read input files as (or None for ASCII)'),
 ]
 
 DEFAULT_COMPILER_SETTINGS = dict([(v[0], v[1]) for v in _DEFAULT_COMPILER_SETTINGS])
@@ -1530,7 +1532,13 @@ class ModuleCompiler(SettingsManager, GenUtils):
         if source and file:
             raise TypeError("Cannot compile from a source string AND file.")
         elif isinstance(file, basestring): # it's a filename.
-            f = open(file) # Raises IOError.
+            encoding = settings.get('encoding')
+            if encoding:
+                f = codecs.open(file, 'r', encoding=encoding)
+            else:
+                f = open(file, 'r') # if no encoding is specified, use the
+                                    # builtin open function, which will
+                                    # effectively read data as a bytestream
             source = f.read()
             f.close()
             self._filePath = file


### PR DESCRIPTION
Hi rtyler,

This adds a `--encoding` command line option that allows you to force a particular file encoding when reading template files. AFAICT Cheetah already supports this via the standard `-*- encoding: -*-` directive, but this was an easier change for me to make than change all of our templates (currently I'm using Cheetah 2.0.1, which happens to work but is super broken in other ways).

The unicode parts were a bit over my head, but I think this is correct. Thoughts?
